### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CC-EXT-SDK/README.md
+++ b/CC-EXT-SDK/README.md
@@ -1,11 +1,11 @@
-#Creative Cloud Extension SDK
+# Creative Cloud Extension SDK
 
 
 Unofficial SDK for building HTML based extensions for Adobe Creative Cloud applications. As of now, it consists of some command line tools, scripts and some templates.
 
 *If you're looking for an easier way to build HTML extensions, check out the [Sublime Text plugin](https://github.com/davidderaedt/CC-Extension-Builder-for-Sublime-Text) or the [Brackets extension](https://github.com/davidderaedt/CC-Extension-Builder-for-Brackets), both built on top of this SDK.*
  
-###createext 
+### createext 
 
 Creates an extension panel from a given template and deploys it.
 
@@ -33,7 +33,7 @@ For additional extension samples, check out the [official samples repository](ht
 
 
 
-###deployext
+### deployext
 
 Copies an existing extension folder to the appropriate location for it to be executed.
 
@@ -57,13 +57,13 @@ Example: To deploy an extension located at `~/my-awesome-ext/` with the ID `com.
 For a sample extension to start with, check out the [official samples repository](https://github.com/Adobe-CEP/Samples).
 
 
-###setdebugmode and disabledebugmode
+### setdebugmode and disabledebugmode
 
 For extensions to run, you should first run `setdebugmode.sh` (mac) or `setdebugmode.bat` (win) once to properly configure your system for extension development. Otherwise, extensions will refuse to launch.
 `disabledebugmode.sh` reverts to the default behavior. Windows users should update the CEP registry key manually.
 
 
-###execextendscript
+### execextendscript
 
 This script executes an ExtendScript (jsx) file via command line in Photoshop, Illustrator, InDesign, or After Effects. Unfortunately, InDesign scripts are not supported on Windows for now.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CC Extension Builder for Sublime Text
+# CC Extension Builder for Sublime Text
 
 This Sublime Text 2 package lets you create HTML/CSS/JS based extension panels for Adobe Creative Cloud applications such as Photoshop, Illustrator, InDesign, or After Effects. It is meant for the current CEP4.2 architecture (compatible with the current "CC" version of those apps).
 
@@ -6,7 +6,7 @@ This Sublime Text 2 package lets you create HTML/CSS/JS based extension panels f
 ![image](assets/screenshot.png)
 
 
-##Installation
+## Installation
 
 
 1. [Download the ZIP of this repository](https://github.com/davidderaedt/CC-Extension-Builder-for-Sublime-Text/archive/master.zip), 
@@ -18,17 +18,17 @@ You should now find a new `CC Extensions` menu under the `Tools` menu.
 Support for *Package control* will come later.
 
 
-##Usage
+## Usage
 
 If you're new to HTML extension development for CC apps, you must first configure your system to allow custom extension debugging. To do so, choose `Tools > CC Extensions > Enable Debug Mode`. You only have to do this once.
 
-###Creating a new extension
+### Creating a new extension
 
 Then, go to `Tools > CC Extensions > Create Extension`. When prompted, choose your extension unique ID, and hit enter. It will generate a pre-deployed extension panel and open the corresponding `manifest.xml` file, which you must edit according to your needs (starting with the "host" list, which determines which CC app this extension applies to, and is set to Photoshop by default).
 
 At this stage, you should be able to open your CC application (say, Photoshop) and choose `Window > extensions > Extension-Name`, which should open a new panel containing a simple button.
 
-###Developing your extension
+### Developing your extension
 
 First, you should select `Project > Add Folder To Project` and choose the created `com.example.extension` folder to get access to your panel's HTML, CSS and javascript files in your sublime project.
 
@@ -37,13 +37,13 @@ To know more about HTML panel development, please refer to the [official documen
 It is a good practice to have your business logic in separated JSX (extendscript) files. To test those files directly, new build systems are added with this package. For example the build system `Photoshop script` will execute the extendScript file directly in Photoshop, without having to reload your panel. Note that only Photoshop, Illustrator and InDesign are supported at this stage.
 
 
-##Troubleshooting
+## Troubleshooting
 
 If nothing seems to happen, chances are you there was a permission issue with the plugin. To fix this, choose `Tools > CC Extensions > Fix Permissions`.
 
 If an extension folder was indeed created, but your CC apps prompts you with an "Unable to load extension" error (or something similar), you should make sure you correctly enabled debug mode on your system.
 
 
-##About
+## About
 
 This plugin was developped on top of the unofficial [Creative Cloud Extension SDK](https://github.com/davidderaedt/CC-EXT-SDK).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
